### PR TITLE
Contain the selected gif in an img tag to prevent Giphy page redirect

### DIFF
--- a/force-app/main/default/aura/SearchGIPHY/SearchGIPHY.cmp
+++ b/force-app/main/default/aura/SearchGIPHY/SearchGIPHY.cmp
@@ -28,7 +28,7 @@
           <div class="slds-modal__content slds-p-around_medium" id="modal-content-id-1">
 
             <div class="preview-image">
-                <img src="{!v.selectedGif}" width="{!v.selectedGifWidth}" height="{!v.selectedGifHeight}" />
+                <img src="{!v.selectedGif}" height="{!v.selectedGifHeight}" />
             </div>
             <br />
             <p>

--- a/force-app/main/default/aura/SearchGIPHY/SearchGIPHY.cmp
+++ b/force-app/main/default/aura/SearchGIPHY/SearchGIPHY.cmp
@@ -28,7 +28,7 @@
           <div class="slds-modal__content slds-p-around_medium" id="modal-content-id-1">
 
             <div class="preview-image">
-              <iframe src="{!v.selectedGif}" width="{!v.selectedGifWidth}" height="{!v.selectedGifHeight}" frameBorder="0" />
+                <img src="{!v.selectedGif}" width="{!v.selectedGifWidth}" height="{!v.selectedGifHeight}" />
             </div>
             <br />
             <p>

--- a/force-app/main/default/aura/SearchGIPHY/SearchGIPHYController.js
+++ b/force-app/main/default/aura/SearchGIPHY/SearchGIPHYController.js
@@ -45,7 +45,8 @@
 
     component.set("v.selectedGifWidth", width);
     component.set("v.selectedGifHeight", height);
-    component.set("v.selectedGif", "https://media0.giphy.com/media/" + id + "/giphy.gif");
+    // Force Giphy to return images limited to 200 pixel height to prevent file size limit error
+    component.set("v.selectedGif", "https://media0.giphy.com/media/" + id + "/200.gif");
 
   },
 

--- a/force-app/main/default/aura/SearchGIPHY/SearchGIPHYController.js
+++ b/force-app/main/default/aura/SearchGIPHY/SearchGIPHYController.js
@@ -44,8 +44,9 @@
     var height = selectedGif.images.original.height;
 
     component.set("v.selectedGifWidth", width);
-    component.set("v.selectedGifHeight", height);
-    component.set("v.selectedGif", "https://media0.giphy.com/media/" + id + "/giphy.gif");
+    component.set("v.selectedGifHeight", 200);
+    // Force Giphy to return images limited to 200 pixel height to prevent file size limit error
+    component.set("v.selectedGif", "https://media0.giphy.com/media/" + id + "/200.gif");
 
   },
 

--- a/force-app/main/default/classes/ChatterHelper.cls
+++ b/force-app/main/default/classes/ChatterHelper.cls
@@ -9,32 +9,26 @@ public with sharing class ChatterHelper {
     Blob imageData = getImageData(imageUrl);
 
     ID fileId = saveFile(fileName, imageData);
-    ID postParentId = UserInfo.getUserId();
 
-    FeedItem post = new FeedItem(
-        ParentId = postParentId,
-        Body = body,
-        IsRichText = true
-    );
+    // Use Salesforce "ConnectApi" class so the animated Gif may be embedded Inline
+    ConnectApi.MessageBodyInput messageInput = new ConnectApi.MessageBodyInput();
+    messageInput.messageSegments = new List<ConnectApi.MessageSegmentInput>();
 
-    insert post;
+    ConnectApi.TextSegmentInput textSegment = new ConnectApi.TextSegmentInput();
+    textSegment.text = chatterText;
+    messageInput.messageSegments.add(textSegment);
 
-    String feedItemId = post.Id;
+    ConnectApi.InlineImageSegmentInput inlineImageSegment = new ConnectApi.InlineImageSegmentInput();
+    inlineImageSegment.fileId = fileId;
+    inlineImageSegment.altText = chatterText;
+    messageInput.messageSegments.add(inlineImageSegment);
 
-    // Add image(s) to the chatter post
-    // Requires 'Allow users to edit posts and comments' in Setup | Chatter | Chatter Settings
-    // because adding the feed attachments edits the original post.
-    // http://salesforce.stackexchange.com/questions/156588/feedattachment-invalid-operation-cannot-create-update-or-delete-feed-attachme
-    List<FeedAttachment> feedAttachments = new List<FeedAttachment>();
-    feedAttachments.add( new FeedAttachment(
-      feedEntityId = feedItemId,
-      recordId = fileId,
-      type = 'Content'
-    ));
+    ConnectApi.FeedItemInput input = new ConnectApi.FeedItemInput();
+    input.body = messageInput;
+    input.subjectId = 'me';
 
-    insert feedAttachments;
-
-    return feedItemId;
+    ConnectApi.FeedElement fe = ConnectApi.ChatterFeeds.postFeedElement(Network.getNetworkId(), input);
+    return fe.Id;
   }
 
   private static ID saveFile(String fileNameWithExt, Blob fileData) {
@@ -47,7 +41,9 @@ public with sharing class ChatterHelper {
 
     insert file;
 
-    return file.Id;
+    // The ConnectApi class requires a ContentDocument Id -- not the ContentVersion Id
+    ContentVersion file2 = [select id,ContentDocumentId from ContentVersion where id= :file.id];
+    return file2.ContentDocumentId;
   }
 
   private static Blob getImageData(String url) {


### PR DESCRIPTION
When the selected image was contained in an <iframe> Giphy was sometimes returning a whole page instead of just an image.  This messed up the popup modal and broke the Chatter Post.
![image](https://user-images.githubusercontent.com/519656/55045260-741d3400-4ffa-11e9-9cb8-a4386a6b364f.png)
